### PR TITLE
Addtional tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ applyTags(bucket, {
   group: 'li',
   classification: SecurityClassification.Unclassified,
   data: { isMaster: true, isPublic: true, role: TagDataRole.Archive },
+  criticality: 'low',
+  commitInfo: true,
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ applyTags(bucket, {
   classification: SecurityClassification.Unclassified,
   data: { isMaster: true, isPublic: true, role: TagDataRole.Archive },
   criticality: 'low',
-  commitInfo: true,
 });
 ```
 

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -63,6 +63,7 @@ export interface TagsBase {
   responderTeam?: string;
   /**
    * collection git info, commit, version etc
+   * @default false
    */
   skipGitInfo?: boolean;
 

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -64,7 +64,7 @@ export interface TagsBase {
   /**
    * collection git info, commit, version etc
    */
-  commitInfo?: boolean;
+  skipGitInfo?: boolean;
 
   /** Data classification tags */
   data?: TagsData;
@@ -84,7 +84,7 @@ export function applyTags(construct: IConstruct, ctx: TagsBase): void {
     throw new Error('Only unclassified constructs can be made public');
   }
 
-  const buildInfo = ctx.commitInfo ? getGitBuildInfo() : undefined;
+  const buildInfo = ctx.skipGitInfo ? undefined : getGitBuildInfo();
 
   // applications tags
   tag(construct, 'linz.app.name', ctx.application);
@@ -94,6 +94,7 @@ export function applyTags(construct: IConstruct, ctx: TagsBase): void {
   // Ownership tags
   tag(construct, 'linz.group', ctx.group);
   tag(construct, 'linz.group.responder', ctx.responderTeam ?? 'NotSet');
+  tag(construct, 'linz.app.criticality', ctx.criticality);
 
   // Git Tags
   if (buildInfo) tag(construct, 'linz.git.hash', buildInfo.hash);

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -51,6 +51,21 @@ export interface TagsBase {
    */
   classification: SecurityClassification;
 
+  /**
+   * Criticality of the resources
+   */
+  criticality: 'critical' | 'high' | 'medium' | 'low';
+
+  /**
+   * THe responder team listed in OpsGenie.
+   * @see https://toitutewhenua.app.opsgenie.com/teams/list
+   */
+  responderTeam?: string;
+  /**
+   * collection git info, commit, version etc
+   */
+  commitInfo?: boolean;
+
   /** Data classification tags */
   data?: TagsData;
 }
@@ -68,30 +83,32 @@ export function applyTags(construct: IConstruct, ctx: TagsBase): void {
   if (ctx.data?.isPublic && ctx.classification !== SecurityClassification.Unclassified) {
     throw new Error('Only unclassified constructs can be made public');
   }
-  const buildInfo = getGitBuildInfo();
+
+  const buildInfo = ctx.commitInfo ? getGitBuildInfo() : undefined;
 
   // applications tags
-  tag(construct, 'linz:app:name', ctx.application);
-  tag(construct, 'linz:app:version', buildInfo.version);
-  tag(construct, 'linz:environment', ctx.environment);
+  tag(construct, 'linz.app.name', ctx.application);
+  if (buildInfo) tag(construct, 'linz.app.version', buildInfo.version);
+  tag(construct, 'linz.environment', ctx.environment);
 
   // Ownership tags
-  tag(construct, 'linz:group', ctx.group);
+  tag(construct, 'linz.group', ctx.group);
+  tag(construct, 'linz.group.responder', ctx.responderTeam ?? 'NotSet');
 
   // Git Tags
-  tag(construct, 'linz:git:hash', buildInfo.hash);
-  tag(construct, 'linz:git:repository', process.env['GITHUB_REPOSITORY'] ?? ctx.repository);
+  if(buildInfo) tag(construct, 'linz.git.hash', buildInfo.hash);
+  tag(construct, 'linz.git.repository', process.env['GITHUB_REPOSITORY'] ?? ctx.repository);
 
   // Github actions build information
-  tag(construct, 'linz:build:id', buildInfo.buildId);
+  if(buildInfo) tag(construct, 'linz.build.id', buildInfo.buildId);
 
   // Security
-  tag(construct, 'linz:security:classification', ctx.classification);
+  tag(construct, 'linz.security.classification', ctx.classification);
   if (ctx.data) applyTagsData(construct, ctx.data);
 }
 
 export function applyTagsData(construct: IConstruct, tags: TagsData): void {
-  tag(construct, 'linz:data:role', tags.role);
-  tag(construct, 'linz:data:is-master', String(tags.isMaster ?? false));
-  tag(construct, 'linz:data:is-public', String(tags.isPublic ?? false));
+  tag(construct, 'linz.data.role', tags.role);
+  tag(construct, 'linz.data.is-master', String(tags.isMaster ?? false));
+  tag(construct, 'linz.data.is-public', String(tags.isPublic ?? false));
 }

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -96,11 +96,11 @@ export function applyTags(construct: IConstruct, ctx: TagsBase): void {
   tag(construct, 'linz.group.responder', ctx.responderTeam ?? 'NotSet');
 
   // Git Tags
-  if(buildInfo) tag(construct, 'linz.git.hash', buildInfo.hash);
+  if (buildInfo) tag(construct, 'linz.git.hash', buildInfo.hash);
   tag(construct, 'linz.git.repository', process.env['GITHUB_REPOSITORY'] ?? ctx.repository);
 
   // Github actions build information
-  if(buildInfo) tag(construct, 'linz.build.id', buildInfo.buildId);
+  if (buildInfo) tag(construct, 'linz.build.id', buildInfo.buildId);
 
   // Security
   tag(construct, 'linz.security.classification', ctx.classification);

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -94,7 +94,7 @@ export function applyTags(construct: IConstruct, ctx: TagsBase): void {
 
   // Ownership tags
   tag(construct, 'linz.group', ctx.group);
-  tag(construct, 'linz.group.responder', ctx.responderTeam ?? 'NotSet');
+  tag(construct, 'linz.responder.team', ctx.responderTeam ?? 'NotSet');
   tag(construct, 'linz.app.criticality', ctx.criticality);
 
   // Git Tags


### PR DESCRIPTION
After a discussion with prod ops, additional tags have been added. The delimiter of ":" in the tag name causes some issues with our existing tags for APM entities, hence the change to "."

Example cdk synth

```
     [ ] [
 │      [ ]   {
 │      [+]     "Key": "linz.app.name",
 │      [+]     "Value": "test-stack"
 │      [+]   },
 │      [+]   {
 │      [+]     "Key": "linz.environment",
 │      [+]     "Value": "nonprod"
 │      [+]   },
 │      [+]   {
 │      [+]     "Key": "linz.group",
 │      [+]     "Value": "STEP"
 │      [+]   },
 │      [+]   {
 │      [+]     "Key": "linz.group.responder",
 │      [+]     "Value": "LANDONLINE - Enablement"
 │      [+]   },
 │      [+]   {
 │      [+]     "Key": "linz.security.classification",
 │      [+]     "Value": "unclassified"
 │      [+]   },
 │      [+]   {

```