### PR TITLE
build: added workflow to lint PR title

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,0 +1,14 @@
+name: lint-pr-title
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: linz/action-pull-request-lint@4744d5a3ab84000afc4eb5dc98b7fd19d7682fff # v1.1.0


### PR DESCRIPTION
Our [previous PR](https://github.com/linz/cdk-tags/pull/14) did not result in a new release due to non-conforming title.

This should help avoid that in the future