### PR TITLE
fix: correct git package url

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "repository": {
-    "url": "git://github.com/linz/cdk-tag.git",
+    "url": "git://github.com/linz/cdk-tags.git",
     "type": "git"
   },
   "peerDependencies": {


### PR DESCRIPTION
#### Motivation

npm published failed to publish due to 

```
npm ERR! 422 Unprocessable Entity - PUT https://registry.npmjs.org/@linzjs%2fcdk-tags - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git://github.com/linz/cdk-tag.git", expected to match "https://github.com/linz/cdk-tags" from provenance
```

#### Modification

Correct the package.json git url location.