### PR TITLE
feat: allow custom data roles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+### Motivation
+
+<!-- TODO: Say why you made your changes. -->
+
+### Modifications
+
+<!-- TODO: Say what changes you made. -->
+
+<!-- TODO: Attach screenshots if you changed the UI. -->
+
+### Verification
+
+<!-- TODO: Say how you tested your changes. -->

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ applyTags(bucket, {
   application: 'basemaps',
   group: 'li',
   classification: SecurityClassification.Unclassified,
-  data: { isMaster: true, isPublic: true, role: TagDataRole.Archive },
+  data: { isMaster: true, isPublic: true, role: 'archive' },
   criticality: 'low',
 });
 ```
@@ -29,7 +29,7 @@ const commonTags: TagsBase = {
   application: 'basemaps',
   group: 'li',
   classification: SecurityClassification.Unclassified,
-  data: { isMaster: true, isPublic: true, role: TagDataRole.Archive },
+  data: { isMaster: true, isPublic: true, role: 'archive },
   criticality: 'low',
 };
 
@@ -39,6 +39,7 @@ const bucket2 = new Bucket(this, 'AnotherImageryArchive');
 applyTags(bucket1, commonTags);
 applyTags(bucket2, commonTags);
 ```
+
 ## Contributing
 
 ### Responder Teams
@@ -49,11 +50,12 @@ Only prod ops team members can create, rename or remove responder teams in OpsGe
 #### Adding responder teams.
 
 Contact the prod ops team in slack at [#team-step-prod-ops](https://linz.enterprise.slack.com/archives/C05Q11EGLA0) to create a new team in [OpsGenie](https://toitutewhenua.app.opsgenie.com/teams/list).
-Once this team is created, add a new responder team to `src/responder-teams.ts` file with the new team name. These two names 
+Once this team is created, add a new responder team to `src/responder-teams.ts` file with the new team name. These two names
 must match to ensure New Relic alerts are sent to the correct team.
 
 #### Renaming responder teams.
-**Warning** Consult the prodOps team regarding renaming a responder team. It is strongly recommended to never rename responder team names as this results in the teams having to apply the new responderTeam value to all their cdk stacks. 
+
+**Warning** Consult the prodOps team regarding renaming a responder team. It is strongly recommended to never rename responder team names as this results in the teams having to apply the new responderTeam value to all their cdk stacks.
 When renaming a responder team, contact the prod ops team in slack at [#team-step-prod-ops](https://linz.enterprise.slack.com/archives/C05Q11EGLA0)
 once the name as been updated, update `src/responder-teams.ts` to match the new name. And ensure you update the `responderTeam` in your `applyTags()` function across all stack the team owns.
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -3,8 +3,10 @@ export interface TagsData {
    * What is the highest importance data in this storage location
    *
    * For example a public master data archive s3://nz-imagery is `archive`
+   *
+   * See {@link CommonDataTags} for some common usages
    */
-  role: TagDataRole;
+  role: string;
   /**
    * Is this data public,
    *
@@ -24,7 +26,14 @@ export interface TagsData {
   isMaster: boolean;
 }
 
-export enum TagDataRole {
-  Primary = 'primary',
-  Archive = 'archive',
-}
+/** A collection of commonly applied tag */
+export const CommonDataTags: Record<string, TagsData> = {
+  /** Master data archive bucket such as s3://nz-imagery */
+  MasterArchive: { role: 'archive', isMaster: true, isPublic: false },
+
+  /** A bucket containing logs such as s3 access logs */
+  Log: { role: 'log', isPublic: false, isMaster: true },
+
+  /** Temporary processing or caching bucket */
+  Temporary: { role: 'temporary', isPublic: false, isMaster: false },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export { getGitBuildInfo } from './build';
-export { SecurityClassification } from './security';
-export type { TagsBase } from './tags';
-export { applyTags, applyTagsData } from './tags';
+export { getGitBuildInfo } from './build.js';
+export { CommonDataTags } from './data.js';
+export { SecurityClassification } from './security.js';
+export type { TagsBase } from './tags.js';
+export { applyTags, applyTagsData } from './tags.js';

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -3,7 +3,7 @@ import { IConstruct } from 'constructs';
 
 import { getGitBuildInfo } from './build.js';
 import { TagsData } from './data.js';
-import { ResponderTeam } from './responder-teams';
+import { ResponderTeam } from './responder-teams.js';
 import { SecurityClassification } from './security.js';
 
 export interface TagsBase {


### PR DESCRIPTION
### Motivation

I am adding roles to buckets and there are too many roles that are not currently listed here causing me to be unable to tag my buckets

<!-- TODO: Say why you made your changes. -->

### Modifications

Allow data roles to be any strings for now and add some common examples

Also applied prettier to README.md

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->