### PR TITLE
feat: made group tag string literal to avoid unexpected values

### DIFF
--- a/src/tags.ts
+++ b/src/tags.ts
@@ -24,11 +24,9 @@ export interface TagsBase {
   application: string;
 
   /**
-   * Human friendly name for LINZ group that the resources belong to
-   *
-   * @example "step" or "li"
+   * LINZ group that the resources belong to
    */
-  group: string;
+  group: 'step' | 'li';
 
   /**
    * Git repository that this construct belongs to


### PR DESCRIPTION
### Motivation

A lot of our New Relic monitoring automation have logic basic on the `linz.group` tag. And unbounded value is going to lead to things falling between the cracks
