### PR TITLE
docs: correct readme and add test to prevent it breaking again

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,1 +1,9 @@
-module.exports = { ...require('@linzjs/style/.eslintrc.cjs') };
+const cfg = {
+  ...require('@linzjs/style/.eslintrc.cjs'),
+};
+
+// Disable no floating promises in tests until https://github.com/nodejs/node/issues/51292 is solved
+const testOverrides = cfg.overrides.find((ovr) => ovr.files.find((f) => f.includes('.test.ts')));
+testOverrides.rules['@typescript-eslint/no-floating-promises'] = 'off';
+
+module.exports = cfg;

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ const bucket = new Bucket(this, 'ImageryArchive');
 
 applyTags(bucket, {
   application: 'basemaps',
+  environment: 'prod',
   group: 'li',
   classification: SecurityClassification.Unclassified,
   data: { isMaster: true, isPublic: true, role: 'archive' },
-  criticality: 'low',
+  impact: 'moderate',
 });
 ```
 
@@ -27,10 +28,11 @@ import { applyTags, SecurityClassification, TagsBase } from '@linzjs/cdk-tags';
 
 const commonTags: TagsBase = {
   application: 'basemaps',
+  environment: 'prod',
   group: 'li',
   classification: SecurityClassification.Unclassified,
   data: { isMaster: true, isPublic: true, role: 'archive' },
-  criticality: 'low',
+  impact: 'moderate',
 };
 
 const bucket1 = new Bucket(this, 'ImageryArchive');

--- a/src/__test__/tags.test.ts
+++ b/src/__test__/tags.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test';
+
+import { IConstruct } from 'constructs';
+
+import { SecurityClassification } from '../security.js';
+import { applyTags } from '../tags.js';
+
+describe('applyTags', async () => {
+  // If this test breaks the README needs to be updated
+  it('should apply example from README.md', () => {
+    applyTags({} as unknown as IConstruct, {
+      application: 'basemaps',
+      environment: 'prod',
+      group: 'li',
+      classification: SecurityClassification.Unclassified,
+      data: { isMaster: true, isPublic: true, role: 'archive' },
+      impact: 'moderate',
+    });
+  });
+});

--- a/src/__test__/tags.test.ts
+++ b/src/__test__/tags.test.ts
@@ -5,7 +5,7 @@ import { IConstruct } from 'constructs';
 import { SecurityClassification } from '../security.js';
 import { applyTags } from '../tags.js';
 
-describe('applyTags', async () => {
+describe('applyTags', () => {
   // If this test breaks the README needs to be updated
   it('should apply example from README.md', () => {
     applyTags({} as unknown as IConstruct, {


### PR DESCRIPTION
### Motivation

The readme example is wrong which makes it hard for users to use this library


### Modifications

Correct the example in the README, then add a unit test to prevent it breaking again.

### Verification

Ran unit tests locally + test pass in CI
