### PR TITLE
chore: security update for Github actions usages

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4
         id: release
         with:
           release-type: node


### PR DESCRIPTION
This pull request is opened automatically by [linz/security-gha-scan](https://github.com/linz/security-gha-scan) to ensure that the usage of Github Actions meets [LINZ security requirements](https://toitutewhenua.atlassian.net/wiki/x/h5SRHQ).

specifically:

- 3rd party actions (anything other than `linz/*`) are pinned with commit SHA
- dependabot is used to keep Github action up to date
  - unverified actions are configured to not auto update

Please review and merge it as soon as possible, contact [#team-step-security](https://linz.enterprise.slack.com/archives/C03278T3HCK) or [#team-step-enablement](https://linz.enterprise.slack.com/archives/CMP0BQ2V7) if you have any question.
