### PR TITLE
build: use pull_request not pull_request_target

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,8 +1,9 @@
 name: lint-pr-title
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
+      - reopened
       - edited
       - synchronize
 


### PR DESCRIPTION
### Motivation

`pull_request_target` is unsafe

### Modifications

swap `pull_request_target` to `pull_request`

### Verification

Fixes #154 
