### PR TITLE
fix: set node version back 20.x

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,3 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: linz/action-typescript@v3
+        with:
+          node-version: '20.x'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Build and test
         uses: linz/action-typescript@v3
+        with:
+          node-version: '20.x'
 
       - name: Publish to NPM
         run: npm publish --provenance --access public


### PR DESCRIPTION
### Motivation

action-typescript moved to node24 default, 

typescript using `node --test` without a glob can have issues with node24.

<!-- TODO: Say why you made your changes. -->

### Modifications

revert back to node20 until `--test` can be fixed.

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
